### PR TITLE
Use env to get Python3 path

### DIFF
--- a/launch_speed_test.sh
+++ b/launch_speed_test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import subprocess
 process = subprocess.Popen(["python3","./speedtest-cli-2ha.py"],
                            stdout=subprocess.DEVNULL,

--- a/speedtest-cli-2ha.py
+++ b/speedtest-cli-2ha.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import requests


### PR DESCRIPTION
As it is a generic binary also used in a Home Assistant container and should be on almost every Linux distribution, it could avoid having a wrong path to Python3.
